### PR TITLE
Removing InstanceMethods as it is deprecated in Rails 3.2 and yields warning

### DIFF
--- a/lib/td/logger/agent/rails/controller.rb
+++ b/lib/td/logger/agent/rails/controller.rb
@@ -7,24 +7,15 @@ module Agent::Rails
       ::ActionController::Base.send(:include, self)
     end
 
-    if defined?(ActiveSupport::Concern)
-      extend ActiveSupport::Concern
-    else
-      # Rails 2
-      def self.included(mod)
-        im = InstanceMethods
-        cm = ClassMethods
-        mod.class_eval do
-          include im
-          extend cm
-        end
+    def self.included(mod)
+      cm = ClassMethods
+      mod.class_eval do
+        extend cm
       end
     end
 
-    module InstanceMethods
-      def event
-        TreasureData::Logger.event
-      end
+    def event
+      TreasureData::Logger.event
     end
 
     module ClassMethods

--- a/lib/td/logger/agent/rails/model.rb
+++ b/lib/td/logger/agent/rails/model.rb
@@ -14,21 +14,11 @@ module Agent::Rails
       ::ActiveRecord::Base.send(:include, self)
     end
 
-    if defined?(ActiveSupport::Concern)
-      extend ActiveSupport::Concern
-    else
-      # Rails 2
-      def self.included(mod)
-        im = InstanceMethods
-        cm = ClassMethods
-        mod.class_eval do
-          include im
-          extend cm
-        end
+    def self.included(mod)
+      cm = ClassMethods
+      mod.class_eval do
+        extend cm
       end
-    end
-
-    module InstanceMethods
     end
 
     module ClassMethods


### PR DESCRIPTION
See: https://github.com/rails/rails/commit/401393b6561adc1ce7101945163c9601257c057a
