### PR TITLE
Fix specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 pkg/*
+spec/tmp/

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -15,28 +15,28 @@ describe TreasureData::Logger::Event do
     end
 
     it 'action' do
-      test_logger.should_receive(:post).with(:doit, {:action=>"doit", :foo=>:bar, :uid=>"uid1"}).twice
+      expect(test_logger).to receive(:post).with(:doit, {:action=>"doit", :foo=>:bar, :uid=>"uid1"}).twice
       TD.event.action(:doit, {:foo=>:bar}, "uid1")
       TD.event.attribute[:uid] = "uid1"
       TD.event.action(:doit, {:foo=>:bar})
     end
 
     it 'register' do
-      test_logger.should_receive(:post).with(:register, {:action=>"register", :uid=>"uid1"}).twice
+      expect(test_logger).to receive(:post).with(:register, {:action=>"register", :uid=>"uid1"}).twice
       TD.event.register("uid1")
       TD.event.attribute[:uid] = "uid1"
       TD.event.register
     end
 
     it 'login' do
-      test_logger.should_receive(:post).with(:login, {:action=>"login", :uid=>"uid1"}).twice
+      expect(test_logger).to receive(:post).with(:login, {:action=>"login", :uid=>"uid1"}).twice
       TD.event.login("uid1")
       TD.event.attribute[:uid] = "uid1"
       TD.event.login
     end
 
     it 'pay' do
-      test_logger.should_receive(:post).with(:pay, {:action=>"pay", :category=>"cat", :sub_category=>"subcat", :name=>"name", :price=>1980, :count=>1, :uid=>"uid1"}).twice
+      expect(test_logger).to receive(:post).with(:pay, {:action=>"pay", :category=>"cat", :sub_category=>"subcat", :name=>"name", :price=>1980, :count=>1, :uid=>"uid1"}).twice
       TD.event.pay("cat", "subcat", "name", 1980, 1, "uid1")
       TD.event.attribute[:uid] = "uid1"
       TD.event.pay("cat", "subcat", "name", 1980, 1)

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -56,11 +56,11 @@ describe TreasureData::Logger::Agent::Rails::Config do
       ENV['TREASURE_DATA_API_KEY'] = 'test1'
       ENV['TREASURE_DATA_DB'] = 'db1'
       c = TreasureData::Logger::Agent::Rails::Config.init
-      c.disabled.should == false
-      c.agent_mode?.should == false
-      c.apikey.should == 'test1'
-      c.database.should == 'db1'
-      c.auto_create_table.should == true
+      expect(c.disabled).to eq(false)
+      expect(c.agent_mode?).to eq(false)
+      expect(c.apikey).to eq('test1')
+      expect(c.database).to eq('db1')
+      expect(c.auto_create_table).to eq(true)
     end
 
     it 'load_file' do
@@ -74,12 +74,12 @@ test:
 EOF
       }
       c = TreasureData::Logger::Agent::Rails::Config.init
-      c.disabled.should == false
-      c.agent_mode?.should == false
-      c.apikey.should == 'test2'
-      c.database.should == 'db2'
-      c.auto_create_table.should == true
-      c.debug_mode.should == true
+      expect(c.disabled).to eq(false)
+      expect(c.agent_mode?).to eq(false)
+      expect(c.apikey).to eq('test2')
+      expect(c.database).to eq('db2')
+      expect(c.auto_create_table).to eq(true)
+      expect(c.debug_mode).to eq(true)
     end
 
     it 'load_file without test' do
@@ -93,7 +93,7 @@ development:
 EOF
       }
       c = TreasureData::Logger::Agent::Rails::Config.init
-      c.disabled.should == true
+      expect(c.disabled).to eq(true)
     end
 
     it 'prefer file than env' do
@@ -110,12 +110,12 @@ test:
 EOF
       }
       c = TreasureData::Logger::Agent::Rails::Config.init
-      c.disabled.should == false
-      c.agent_mode?.should == false
-      c.apikey.should == 'test4'
-      c.database.should == 'db4'
-      c.auto_create_table.should == false
-      c.debug_mode.should == false
+      expect(c.disabled).to eq(false)
+      expect(c.agent_mode?).to eq(false)
+      expect(c.apikey).to eq('test4')
+      expect(c.database).to eq('db4')
+      expect(c.auto_create_table).to eq(false)
+      expect(c.debug_mode).to eq(false)
     end
 
     it 'agent mode' do
@@ -128,11 +128,11 @@ test:
 EOF
       }
       c = TreasureData::Logger::Agent::Rails::Config.init
-      c.disabled.should == false
-      c.agent_mode?.should == true
-      c.tag.should == 'td.db5'
-      c.agent_host.should == 'localhost'
-      c.agent_port.should == 24224
+      expect(c.disabled).to eq(false)
+      expect(c.agent_mode?).to eq(true)
+      expect(c.tag).to eq('td.db5')
+      expect(c.agent_host).to eq('localhost')
+      expect(c.agent_port).to eq(24224)
     end
 
     it 'test mode' do
@@ -146,14 +146,14 @@ test:
 EOF
       }
       c = TreasureData::Logger::Agent::Rails::Config.init
-      c.disabled.should == false
-      c.test_mode?.should == true
+      expect(c.disabled).to eq(false)
+      expect(c.test_mode?).to eq(true)
     end
   end
 end
 
 describe ActiveSupport::TimeWithZone do
   it 'has to_msgpack' do
-    ActiveSupport::TimeWithZone.method_defined?(:to_msgpack).should == true
+    expect(ActiveSupport::TimeWithZone.method_defined?(:to_msgpack)).to eq(true)
   end
 end

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -154,6 +154,6 @@ end
 
 describe ActiveSupport::TimeWithZone do
   it 'has to_msgpack' do
-    ActiveSupport::TimeWithZone.method_defined?(:to_msgpack).should be_true
+    ActiveSupport::TimeWithZone.method_defined?(:to_msgpack).should == true
   end
 end

--- a/spec/td_logger_spec.rb
+++ b/spec/td_logger_spec.rb
@@ -6,19 +6,19 @@ describe TreasureData::Logger::TreasureDataLogger do
     it 'with apikey' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1')
       td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should be_false
+      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == false
     end
 
     it 'with apikey and use_ssl' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1', :use_ssl => true)
       td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should be_true
+      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == true
     end
 
     it 'with apikey and ssl' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1', :ssl => true)
       td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should be_true
+      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == true
     end
 
     it 'with apikey and HTTP endpoint' do
@@ -26,7 +26,7 @@ describe TreasureData::Logger::TreasureDataLogger do
       td.instance_variable_get(:@client).api.apikey.should == 'test_1'
       td.instance_variable_get(:@client).api.instance_variable_get(:@host).should == "idontexi.st"
       td.instance_variable_get(:@client).api.instance_variable_get(:@port).should == 80
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should be_false
+      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == false
     end
 
     it 'with apikey and HTTPS endpoint' do
@@ -34,7 +34,7 @@ describe TreasureData::Logger::TreasureDataLogger do
       td.instance_variable_get(:@client).api.apikey.should == 'test_1'
       td.instance_variable_get(:@client).api.instance_variable_get(:@host).should == "idontexi.st"
       td.instance_variable_get(:@client).api.instance_variable_get(:@port).should == 443
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should be_true
+      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == true
     end
 
     it 'db config' do

--- a/spec/td_logger_spec.rb
+++ b/spec/td_logger_spec.rb
@@ -5,49 +5,49 @@ describe TreasureData::Logger::TreasureDataLogger do
   context 'init' do
     it 'with apikey' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1')
-      td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == false
+      expect(td.instance_variable_get(:@client).api.apikey).to eq('test_1')
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@ssl)).to eq(false)
     end
 
     it 'with apikey and use_ssl' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1', :use_ssl => true)
-      td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == true
+      expect(td.instance_variable_get(:@client).api.apikey).to eq('test_1')
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@ssl)).to eq(true)
     end
 
     it 'with apikey and ssl' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1', :ssl => true)
-      td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == true
+      expect(td.instance_variable_get(:@client).api.apikey).to eq('test_1')
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@ssl)).to eq(true)
     end
 
     it 'with apikey and HTTP endpoint' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1', :endpoint => "http://idontexi.st")
-      td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@host).should == "idontexi.st"
-      td.instance_variable_get(:@client).api.instance_variable_get(:@port).should == 80
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == false
+      expect(td.instance_variable_get(:@client).api.apikey).to eq('test_1')
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@host)).to eq("idontexi.st")
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@port)).to eq(80)
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@ssl)).to eq(false)
     end
 
     it 'with apikey and HTTPS endpoint' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1', :endpoint => "https://idontexi.st")
-      td.instance_variable_get(:@client).api.apikey.should == 'test_1'
-      td.instance_variable_get(:@client).api.instance_variable_get(:@host).should == "idontexi.st"
-      td.instance_variable_get(:@client).api.instance_variable_get(:@port).should == 443
-      td.instance_variable_get(:@client).api.instance_variable_get(:@ssl).should == true
+      expect(td.instance_variable_get(:@client).api.apikey).to eq('test_1')
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@host)).to eq("idontexi.st")
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@port)).to eq(443)
+      expect(td.instance_variable_get(:@client).api.instance_variable_get(:@ssl)).to eq(true)
     end
 
     it 'db config' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_1')
       time = Time.now
-      td.should_receive(:add).with('db1', 'table1', {:foo => :bar, :time => time.to_i})
+      expect(td).to receive(:add).with('db1', 'table1', {:foo => :bar, :time => time.to_i})
       td.post_with_time('table1', {:foo => :bar}, time)
     end
 
     it 'fluent-logger-td compat' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_2')
       time = Time.now
-      td.should_receive(:add).with('overwrite', 'table1', {:foo => :bar, :time => time.to_i})
+      expect(td).to receive(:add).with('overwrite', 'table1', {:foo => :bar, :time => time.to_i})
       td.post_with_time('overwrite.table1', {:foo => :bar}, time)
     end
 
@@ -61,22 +61,22 @@ describe TreasureData::Logger::TreasureDataLogger do
   context 'validate' do
     it 'validate table name' do
       td = TreasureData::Logger::TreasureDataLogger.new('db1', :apikey => 'test_4')
-      proc {
+      expect {
         td.post('invalid-name', {})
-      }.should raise_error(RuntimeError)
-      proc {
+      }.to raise_error(RuntimeError)
+      expect {
         td.post('', {})
-      }.should raise_error(RuntimeError)
-      proc {
+      }.to raise_error(RuntimeError)
+      expect {
         td.post('9', {})
-      }.should raise_error(RuntimeError)
+      }.to raise_error(RuntimeError)
     end
 
     it 'validate database name' do
       td = TreasureData::Logger::TreasureDataLogger.new('invalid-db-name', :apikey => 'test_5')
-      proc {
+      expect {
         td.post('table', {})
-      }.should raise_error(RuntimeError)
+      }.to raise_error(RuntimeError)
     end
   end
 end

--- a/td-logger.gemspec
+++ b/td-logger.gemspec
@@ -34,5 +34,5 @@ EOF
   gem.add_dependency "td-client", "~> 0.8.66"
   gem.add_dependency "fluent-logger", "~> 0.4.9"
   gem.add_development_dependency 'rake', '>= 0.9.2'
-  gem.add_development_dependency 'rspec', '>= 2.7.0'
+  gem.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
Current (this PR) result:

```console
$ bundle exec rake spec
/Users/uu59/.rbenv/versions/ruby-2.1.3/bin/ruby -I/Users/uu59/.rbenv/versions/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.0/lib:/Users/uu59/.rbenv/versions/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-support-3.2.1/lib /Users/uu59/.rbenv/versions/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.0/exe/rspec spec/event_spec.rb spec/rails_config_spec.rb spec/td_logger_spec.rb
Disabling Treasure Data event logger.
..................E, [2015-02-12T14:08:33.864963 #82800] ERROR -- : TreasureDataLogger: Invalid table name "invalid-name": Table name must only consist of lower-case alpha-numeric characters and '_'.
E, [2015-02-12T14:08:33.865130 #82800] ERROR -- : TreasureDataLogger: Invalid database name nil: Empty database name is not allowed
E, [2015-02-12T14:08:33.865277 #82800] ERROR -- : TreasureDataLogger: Invalid table name "9": Table name must be between 3 and 255 characters long. Got 1 character.
.E, [2015-02-12T14:08:33.866248 #82800] ERROR -- : TreasureDataLogger: Invalid database name "invalid-db-name": Database name must only consist of lower-case alpha-numeric characters and '_'.
.

Finished in 0.09199 seconds (files took 0.10257 seconds to load)
20 examples, 0 failures
```