### PR TITLE
Ignore test files coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear!('test_frameworks')
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Sorry #17 didn't correctly gathering test coverage that including `spec/*` files.

You can see the files what target in as below.

```console
$ COVERALLS_NOISY=true bundle exec rake spec
/Users/uu59/.rbenv/versions/ruby-2.1.3/bin/ruby -I/Users/uu59/.rbenv/versions/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.0/lib:/Users/uu59/.rbenv/versions/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-support-3.2.1/lib /Users/uu59/.rbenv/versions/ruby-2.1.3/lib/ruby/gems/2.1.0/gems/rspec-core-3.2.0/exe/rspec spec/event_spec.rb spec/rails_config_spec.rb spec/td_logger_spec.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'test_frameworks' settings.
Disabling Treasure Data event logger.
..................E, [2015-02-13T11:39:19.537528 #3282] ERROR -- : TreasureDataLogger: Invalid table name "invalid-name": Table name must only consist of lower-case alpha-numeric characters and '_'.
E, [2015-02-13T11:39:19.537671 #3282] ERROR -- : TreasureDataLogger: Invalid database name nil: Empty database name is not allowed
E, [2015-02-13T11:39:19.537742 #3282] ERROR -- : TreasureDataLogger: Invalid table name "9": Table name must be between 3 and 255 characters long. Got 1 character.
.E, [2015-02-13T11:39:19.538732 #3282] ERROR -- : TreasureDataLogger: Invalid database name "invalid-db-name": Database name must only consist of lower-case alpha-numeric characters and '_'.
.

Finished in 0.0845 seconds (files took 0.29398 seconds to load)
20 examples, 0 failures

[Coveralls] Outside the CI environment, not sending data.
[Coveralls] Some handy coverage stats:
  * lib/td-logger.rb => 100%
  * lib/td/logger.rb => 69%
  * lib/td/logger/agent/rack.rb => 53%
  * lib/td/logger/agent/rails.rb => 61%
  * lib/td/logger/agent/rails/config.rb => 83%
  * lib/td/logger/agent/rails/controller.rb => 62%
  * lib/td/logger/event.rb => 84%
  * lib/td/logger/td_logger.rb => 39%
```