### PR TITLE
can set the timing of buffering

### DIFF
--- a/lib/td/logger/td_logger.rb
+++ b/lib/td/logger/td_logger.rb
@@ -46,11 +46,11 @@ class TreasureDataLogger < Fluent::Logger::LoggerBase
     @map = {}  # (db,table) => buffer:String
     @queue = []
 
-    @chunk_limit = 8 * 1024 * 1024
+    @chunk_limit = options[:chunk_limit] || 8 * 1024 * 1024
     @queue_limit = 50
 
-    @flush_interval = 2
-    @max_flush_interval = 300
+    @flush_interval = options[:flush_interval] || 2
+    @max_flush_interval = options[:max_flush_interval] || 300
     @retry_wait = 1.0
     @retry_limit = 12
 


### PR DESCRIPTION
ref  #13

Now, the same table in the same database, following the buffering is performed.

- When the total of the data that has been post after send the previous api does not exceed the chunk_limit (default: 8 * 1024 * 1024)
- When not after the specified time after throwing the previous api(flush_interval(default: 2) 〜  max_flush_interval(default 300))

https://github.com/treasure-data/td-logger-ruby/blob/v0.3.23/lib/td/logger/td_logger.rb#L261
https://github.com/treasure-data/td-logger-ruby/blob/v0.3.23/lib/td/logger/td_logger.rb#L136

However, these values a user can not be changed.

With this patch, a user will be able to specify when you create Logger.

```
TreasureData.open('db', chunk_limit: 10 * 1024 * 1024, flush_interval: 3, max_flush_interval: 400)
```