### PR TITLE
Disable warnings by ENV["DISABLE_WARNING"]

### DIFF
--- a/lib/td/logger/agent/rails.rb
+++ b/lib/td/logger/agent/rails.rb
@@ -14,7 +14,7 @@ module Agent::Rails
   def self.init(rails)
     c = Config.init
     if c.disabled
-      warn 'Disabling Treasure Data event logger.'
+      warn 'Disabling Treasure Data event logger.' if c.show_warning
       ::TreasureData::Logger.open_null
       return false
     end

--- a/lib/td/logger/agent/rails/config.rb
+++ b/lib/td/logger/agent/rails/config.rb
@@ -38,9 +38,11 @@ module Agent::Rails
     attr_reader :apikey, :database, :auto_create_table
     attr_reader :access_log_table, :debug_mode, :test_mode
     attr_accessor :disabled
+    attr_reader :show_warning
 
     def initialize
       @disabled = false
+      @show_warning = ENV.fetch("DISABLE_WARNING") { true }
     end
 
     def agent_mode?
@@ -71,7 +73,7 @@ module Agent::Rails
 
       return c
     rescue
-      warn "Disabling Treasure Data event logger: #{$!}"
+      warn "Disabling Treasure Data event logger: #{$!}" if c.show_warning
       c.disabled = true
       return c
     end


### PR DESCRIPTION
Hello there 👋 

Our team is using treasure data gem and we would like to disable the warning in test environment.

This PR introduced a new attribute + one ENV to achieve it, the old behaviour still retain, anyone wants to disable it need to set an env variable: `DISABLE_WARNING` .

Please let me know the preferable way to handle this.

Thanks! 