### PR TITLE
Delay extending Rails until loaded

### DIFF
--- a/lib/td/logger/agent/rails/controller.rb
+++ b/lib/td/logger/agent/rails/controller.rb
@@ -4,7 +4,10 @@ module Agent::Rails
   module ControllerExtension
 
     def self.init
-      ::ActionController::Base.send(:include, self)
+      mdl = self
+      ActiveSupport.on_load :action_controller do
+        ::ActionController::Base.send(:include, mdl)
+      end
     end
 
     def self.included(mod)


### PR DESCRIPTION
When extending Rails, instrumentation should be used to wait until the component being extended is fully loaded. Without this, it triggers the loading early through the autoloader which can lead to other problems.

For more background see https://github.com/rails/rails/issues/36546.