### PR TITLE
Add missing licenses

### DIFF
--- a/td-logger.gemspec
+++ b/td-logger.gemspec
@@ -24,6 +24,7 @@ EOF
   #gem.homepage    = %q{https://github.com/treasure-data/td-logger-ruby}
   gem.description = %q{Treasure Data logging library}
   gem.summary     = gem.description
+  gem.licenses    = ["Apache-2.0"]
 
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
ref. https://guides.rubygems.org/specification-reference/#licenses=

Rebased version of https://github.com/treasure-data/td-logger-ruby/pull/41 by @kenhys