### PR TITLE
Ruby 3.1 (psych 4.0) rejects a config/treasure_data.yml file which includes aliases

### DIFF
--- a/lib/td/logger/agent/rails/config.rb
+++ b/lib/td/logger/agent/rails/config.rb
@@ -121,12 +121,12 @@ module Agent::Rails
     end
 
     def load_yaml(path)
-      require 'yaml'
+      require 'td/logger/agent/rails/yaml'
       require 'erb'
 
       src = File.read(path)
       yaml = ERB.new(src).result
-      YAML.load(yaml)
+      YAML.unsafe_load(yaml)
     end
   end
 

--- a/lib/td/logger/agent/rails/yaml.rb
+++ b/lib/td/logger/agent/rails/yaml.rb
@@ -1,0 +1,8 @@
+require 'yaml'
+
+unless YAML.respond_to?(:unsafe_load)
+  # Ruby < 2.6
+  class << YAML
+    alias unsafe_load load
+  end
+end


### PR DESCRIPTION
Ruby 3.1 comes with psych 4.0, which includes backward incompatibility.  The `YAML.load` method was an alias of `unsafe_load` in Ruby 3.0 but now it is an alias of `safe_load` in Ruby 3.1.  `safe_load` rejects YAML aliases or non-standard values, it may reject the `config/treasure_data.yml` file if it contains an alias.

Even worse, td-logger ignores any exception during initialization, we get no exception for this.

I believe `config/treasure_data.yml` is a trusted file, I propose to use `unsafe_load` explicitly for all version of ruby (psych).