### PR TITLE
Allow use td-client v2.0+

### DIFF
--- a/spec/td/logger/agent/rack_spec.rb
+++ b/spec/td/logger/agent/rack_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require "rack/mock"
+require 'rack/builder'
 require 'td/logger/agent/rack'
 
 describe TreasureData::Logger::Agent::Rack::Hook do

--- a/td-logger.gemspec
+++ b/td-logger.gemspec
@@ -32,7 +32,7 @@ EOF
   gem.require_paths = ['lib']
 
   gem.add_dependency "msgpack", ">= 0.5.6", "< 2.0"
-  gem.add_dependency "td-client", ">= 0.8.66", "< 2.0"
+  gem.add_dependency "td-client", ">= 0.8.66", "< 3.0"
   gem.add_dependency "fluent-logger", ">= 0.5.0", "< 2.0"
   gem.add_development_dependency 'rake', '>= 0.9.2'
   gem.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Treasure Data released td-client-ruby v2.0, which version includes Ruby 3.2 support.
However, this gem doesn't allow install the new version of client library since this gem requires `< 2.0`. Then, this pull request relaxes the gem requirements for td client.

After merging this pull request, TD Toolbelt will be able to install the client library v2.0 as well.